### PR TITLE
Update test2.py

### DIFF
--- a/test2.py
+++ b/test2.py
@@ -16,6 +16,8 @@ def act():
         can.move(rect, 5, 0)
         can.update()
         can.after(1, act)
+    else:
+        can.after(1, act2)
         
 
 def act2():
@@ -29,7 +31,6 @@ def act2():
 
 def key_down(key):
     act()
-    act2()
     
 
 can.bind("<Button-1>", key_down)


### PR DESCRIPTION
The problem is that `can.after(1, act)` is non-blocking and doesn't call `act()` and wait for it to finish before moving onto the next line of code - it instead schedules it to be called later. This means that in `key_down`, when you call `act()` then `act2()` it does not move your rectangle all the way to the right then all the way down, but interleaves moving it right and down. In order to wait for the rectangle to move all the way right before starting moving it down, schedule `act2()` after `act()` has finished by using the `else` of the existing `if` statement.